### PR TITLE
allocate slice with known capacity in *ListImpl() functions (#102)

### DIFF
--- a/address_set.go
+++ b/address_set.go
@@ -113,8 +113,6 @@ func (odbi *ovndb) asDelImp(name string) (*OvnCommand, error) {
 
 // Get all addressset
 func (odbi *ovndb) asListImp() ([]*AddressSet, error) {
-	var listAS []*AddressSet
-
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
@@ -123,6 +121,7 @@ func (odbi *ovndb) asListImp() ([]*AddressSet, error) {
 		return nil, ErrorSchema
 	}
 
+	listAS := make([]*AddressSet, 0, len(cacheAddressSet))
 	for uuid, drows := range cacheAddressSet {
 		ta := &AddressSet{
 			UUID:       uuid,

--- a/chassis.go
+++ b/chassis.go
@@ -124,8 +124,6 @@ func (odbi *ovndb) chassisDelImp(name string) (*OvnCommand, error) {
 }
 
 func (odbi *ovndb) chassisListImp() ([]*Chassis, error) {
-	var listChassis []*Chassis
-
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
@@ -135,6 +133,7 @@ func (odbi *ovndb) chassisListImp() ([]*Chassis, error) {
 		return nil, ErrorSchema
 	}
 
+	listChassis := make([]*Chassis, 0, len(cacheChassis))
 	for uuid := range cacheChassis {
 		ch, err := odbi.rowToChassis(uuid)
 		if err != nil {

--- a/dhcp_options.go
+++ b/dhcp_options.go
@@ -144,8 +144,6 @@ func (odbi *ovndb) dhcpOptionsDelImp(uuid string) (*OvnCommand, error) {
 
 // List all dhcp options
 func (odbi *ovndb) dhcpOptionsListImp() ([]*DHCPOptions, error) {
-	var listDHCP []*DHCPOptions
-
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
@@ -154,6 +152,7 @@ func (odbi *ovndb) dhcpOptionsListImp() ([]*DHCPOptions, error) {
 		return nil, ErrorSchema
 	}
 
+	listDHCP := make([]*DHCPOptions, 0, len(cacheDHCPOptions))
 	for uuid := range cacheDHCPOptions {
 		listDHCP = append(listDHCP, odbi.rowToDHCPOptions(uuid))
 	}

--- a/encap.go
+++ b/encap.go
@@ -31,7 +31,6 @@ type Encap struct {
 }
 
 func (odbi *ovndb) encapListImp(chassisName string) ([]*Encap, error) {
-
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
@@ -40,8 +39,6 @@ func (odbi *ovndb) encapListImp(chassisName string) ([]*Encap, error) {
 		return nil, ErrorNotFound
 	}
 
-	var encaps []*Encap
-	var chFound bool
 	for _, drows := range cacheChassis {
 		if ch, ok := drows.Fields["name"].(string); ok && ch == chassisName {
 			if enc, ok := drows.Fields["encaps"]; ok {
@@ -52,12 +49,13 @@ func (odbi *ovndb) encapListImp(chassisName string) ([]*Encap, error) {
 						if err != nil {
 							return nil, err
 						}
-						encaps = append(encaps, cenc)
+						return []*Encap{cenc}, nil
 					} else {
 						return nil, fmt.Errorf("type libovsdb.UUID casting failed")
 					}
 				case libovsdb.OvsSet:
 					if en, ok := enc.(libovsdb.OvsSet); ok {
+						encaps := make([]*Encap, 0, len(en.GoSet))
 						for _, e := range en.GoSet {
 							if euid, ok := e.(libovsdb.UUID); ok {
 								enc, err := odbi.rowToEncap(euid.GoUUID)
@@ -67,20 +65,16 @@ func (odbi *ovndb) encapListImp(chassisName string) ([]*Encap, error) {
 								encaps = append(encaps, enc)
 							}
 						}
+						return encaps, nil
 					} else {
 						return nil, fmt.Errorf("type libovsdb.OvsSet casting failed")
 					}
 				}
 			}
-			chFound = true
-			break
+			return []*Encap{}, nil
 		}
 	}
-	if !chFound {
-		return nil, ErrorNotFound
-	}
-	return encaps, nil
-
+	return nil, ErrorNotFound
 }
 
 func (odbi *ovndb) rowToEncap(uuid string) (*Encap, error) {

--- a/logical_switch_port.go
+++ b/logical_switch_port.go
@@ -397,8 +397,6 @@ func (odbi *ovndb) lspGetImp(lsp string) (*LogicalSwitchPort, error) {
 
 // Get all lport by lswitch
 func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
-	var listLSP []*LogicalSwitchPort
-
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
@@ -406,7 +404,6 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 	if !ok {
 		return nil, ErrorSchema
 	}
-	var lsFound bool
 	for _, drows := range cacheLogicalSwitch {
 		if rlsw, ok := drows.Fields["name"].(string); ok && rlsw == lsw {
 			ports := drows.Fields["ports"]
@@ -414,6 +411,7 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 				switch ports.(type) {
 				case libovsdb.OvsSet:
 					if ps, ok := ports.(libovsdb.OvsSet); ok {
+						listLSP := make([]*LogicalSwitchPort, 0, len(ps.GoSet))
 						for _, p := range ps.GoSet {
 							if vp, ok := p.(libovsdb.UUID); ok {
 								tp, err := odbi.rowToLogicalPort(vp.GoUUID)
@@ -423,6 +421,7 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 								listLSP = append(listLSP, tp)
 							}
 						}
+						return listLSP, nil
 					} else {
 						return nil, fmt.Errorf("type libovsdb.OvsSet casting failed")
 					}
@@ -432,7 +431,7 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 						if err != nil {
 							return nil, fmt.Errorf("Failed to get logical port: %s", err)
 						}
-						listLSP = append(listLSP, tp)
+						return []*LogicalSwitchPort{tp}, nil
 					} else {
 						return nil, fmt.Errorf("type libovsdb.UUID casting failed")
 					}
@@ -440,12 +439,8 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 					return nil, fmt.Errorf("Unsupported type found in ovsdb rows")
 				}
 			}
-			lsFound = true
-			break
+			return []*LogicalSwitchPort{}, nil
 		}
 	}
-	if !lsFound {
-		return nil, ErrorNotFound
-	}
-	return listLSP, nil
+	return nil, ErrorNotFound
 }

--- a/meter.go
+++ b/meter.go
@@ -169,11 +169,11 @@ func (odbi *ovndb) meterDelImp(name ...string) (*OvnCommand, error) {
 func (odbi *ovndb) meterListImp() ([]*Meter, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
-	var ListMeter []*Meter
 	cacheMeter, ok := odbi.cache[TableMeter]
 	if !ok {
 		return nil, ErrorNotFound
 	}
+	ListMeter := make([]*Meter, 0, len(cacheMeter))
 	for uuid := range cacheMeter {
 		ListMeter = append(ListMeter, odbi.rowToMeter(uuid))
 	}
@@ -184,11 +184,11 @@ func (odbi *ovndb) meterListImp() ([]*Meter, error) {
 func (odbi *ovndb) meterBandsListImp() ([]*MeterBand, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
-	var ListMeterBands []*MeterBand
 	cacheMeterBands, ok := odbi.cache[TableMeterBand]
 	if !ok {
 		return nil, ErrorNotFound
 	}
+	ListMeterBands := make([]*MeterBand, 0, len(cacheMeterBands))
 	for uuid := range cacheMeterBands {
 		meterBand, err := odbi.rowToMeterBand(uuid)
 		if err != nil {


### PR DESCRIPTION
The current implementation of *ListImpl() functions allocate more memory
than that is required. We can just allocate the slice with exact
capacity as we know the number of the logical resources.

Signed-off-by: Yun Zhou <yunz@nvidia.com>